### PR TITLE
Make prjn.IsOff() faster

### DIFF
--- a/axon/layer_test.go
+++ b/axon/layer_test.go
@@ -121,3 +121,45 @@ func TestLayerToJson(t *testing.T) {
 		assert.InDelta(t, origWeight, copyWeight, 0.001)
 	}
 }
+
+func TestLayerBase_IsOff(t *testing.T) {
+	net := NewNetwork("LayerTest")
+	shape := []int{2, 2}
+	inputLayer := net.AddLayer("Input", shape, emer.Input).(AxonLayer)
+	inputLayer2 := net.AddLayer("Input2", shape, emer.Input).(AxonLayer)
+	hiddenLayer := net.AddLayer("Hidden", shape, emer.Hidden).(AxonLayer)
+	outputLayer := net.AddLayer("Output", shape, emer.Target).(AxonLayer)
+
+	full := prjn.NewFull()
+	inToHid := net.ConnectLayers(inputLayer, hiddenLayer, full, emer.Forward)
+	in2ToHid := net.ConnectLayers(inputLayer2, hiddenLayer, full, emer.Forward)
+	hidToOut, outToHid := net.BidirConnectLayers(hiddenLayer, outputLayer, full)
+	net.Defaults()
+
+	assert.NoError(t, net.Build())
+
+	assert.False(t, inputLayer.IsOff())
+
+	inputLayer.SetOff(true)
+	assert.True(t, inputLayer.IsOff())
+	assert.False(t, hiddenLayer.IsOff())
+	assert.True(t, inToHid.IsOff())
+	assert.False(t, in2ToHid.IsOff())
+
+	inputLayer2.SetOff(true)
+	assert.True(t, inputLayer2.IsOff())
+	assert.False(t, hiddenLayer.IsOff())
+	assert.True(t, in2ToHid.IsOff())
+
+	hiddenLayer.SetOff(true)
+	assert.True(t, hiddenLayer.IsOff())
+	assert.True(t, hidToOut.IsOff())
+	assert.True(t, outToHid.IsOff())
+
+	hiddenLayer.SetOff(false)
+	assert.False(t, hiddenLayer.IsOff())
+	assert.False(t, hidToOut.IsOff())
+	assert.False(t, outToHid.IsOff())
+	assert.True(t, inToHid.IsOff())
+	assert.True(t, in2ToHid.IsOff())
+}

--- a/axon/prjnbase.go
+++ b/axon/prjnbase.go
@@ -59,10 +59,10 @@ func (ps *PrjnBase) SendLay() emer.Layer   { return ps.Send }
 func (ps *PrjnBase) Pattern() prjn.Pattern { return ps.Pat }
 func (ps *PrjnBase) Type() emer.PrjnType   { return ps.Typ }
 func (ps *PrjnBase) PrjnTypeName() string  { return ps.Typ.String() }
+func (ps *PrjnBase) IsOff() bool           { return ps.Off }
 
-func (ps *PrjnBase) IsOff() bool {
-	return ps.Off || ps.Recv.IsOff() || ps.Send.IsOff()
-}
+// SetOff individual projection. Careful: Layer.SetOff(true) will reactivate all prjns of that layer,
+// so prjn-level lesioning should always be done last.
 func (ps *PrjnBase) SetOff(off bool) { ps.Off = off }
 
 // Connect sets the connectivity between two layers and the pattern to use in interconnecting them


### PR DESCRIPTION
Make `prjn.IsOff()` faster by doing more work during Layer.SetOff().

As I mention, this has this unexpected failure mode on this Network A --prjn--> B:
1. Turn prjn off
2. Turn A off
3. Turn B off
4. Turn A on
5. Turn B on

Now prjn will be on as well.
This removes 2 indirect function calls in the tight loop of SendSpikes, should shave off 3-5% of perf for boa / bench.

See corresponding emergent PR: https://github.com/emer/emergent/pull/101