### PR TITLE
Rm Type Assertion for GFmSpikeRaw

### DIFF
--- a/axon/axon.go
+++ b/axon/axon.go
@@ -134,6 +134,12 @@ type AxonLayer interface {
 	// DecayState decays activation state by given proportion (default is on ly.Act.Init.Decay)
 	DecayState(decay, glong float32)
 
+	// RecvPrjns returns the slice of receiving projections for this layer
+	RecvPrjns() *AxonPrjns
+
+	// SendPrjns returns the slice of sending projections for this layer
+	SendPrjns() *AxonPrjns
+
 	//////////////////////////////////////////////////////////////////////////////////////
 	//  Cycle Methods
 
@@ -273,4 +279,10 @@ type AxonPrjn interface {
 	// SynFail updates synaptic weight failure only -- normally done as part of DWt
 	// and WtFmDWt, but this call can be used during testing to update failing synapses.
 	SynFail(ctime *Time)
+}
+
+type AxonPrjns []AxonPrjn
+
+func (pl *AxonPrjns) Add(p AxonPrjn) {
+	(*pl) = append(*pl, p)
 }

--- a/axon/basic_test.go
+++ b/axon/basic_test.go
@@ -78,7 +78,11 @@ func newTestNet() *Network {
 func TestSynVals(t *testing.T) {
 	testNet := newTestNet()
 	hidLay := testNet.LayerByName("Hidden").(*Layer)
-	fmIn := hidLay.RcvPrjns.SendName("Input").(*Prjn)
+	p, err := hidLay.SendNameTry("Input")
+	if err != nil {
+		t.Error(err)
+	}
+	fmIn := p.(*Prjn)
 
 	bfWt := fmIn.SynVal("Wt", 1, 1)
 	if mat32.IsNaN(bfWt) {

--- a/axon/layer.go
+++ b/axon/layer.go
@@ -294,12 +294,12 @@ func (ly *Layer) RecvPrjnVals(vals *[]float32, varNm string, sendLay emer.Layer,
 	}
 	var pj emer.Prjn
 	if prjnType != "" {
-		pj, err = sendLay.SendPrjns().RecvNameTypeTry(ly.Nm, prjnType)
+		pj, err = sendLay.RecvNameTypeTry(ly.Nm, prjnType)
 		if pj == nil {
-			pj, err = sendLay.SendPrjns().RecvNameTry(ly.Nm)
+			pj, err = sendLay.RecvNameTry(ly.Nm)
 		}
 	} else {
-		pj, err = sendLay.SendPrjns().RecvNameTry(ly.Nm)
+		pj, err = sendLay.RecvNameTry(ly.Nm)
 	}
 	if pj == nil {
 		return err
@@ -340,12 +340,12 @@ func (ly *Layer) SendPrjnVals(vals *[]float32, varNm string, recvLay emer.Layer,
 	}
 	var pj emer.Prjn
 	if prjnType != "" {
-		pj, err = recvLay.RecvPrjns().SendNameTypeTry(ly.Nm, prjnType)
+		pj, err = recvLay.SendNameTypeTry(ly.Nm, prjnType)
 		if pj == nil {
-			pj, err = recvLay.RecvPrjns().SendNameTry(ly.Nm)
+			pj, err = recvLay.SendNameTry(ly.Nm)
 		}
 	} else {
-		pj, err = recvLay.RecvPrjns().SendNameTry(ly.Nm)
+		pj, err = recvLay.SendNameTry(ly.Nm)
 	}
 	if pj == nil {
 		return err
@@ -371,6 +371,19 @@ func (ly *Layer) PoolTry(idx int) (*Pool, error) {
 		return nil, fmt.Errorf("Layer Pool index: %v out of range, N = %v", idx, np)
 	}
 	return &(ly.Pools[idx]), nil
+}
+
+func (ly *Layer) SendNameTry(sender string) (emer.Prjn, error) {
+	return emer.SendNameTry(ly, sender)
+}
+func (ly *Layer) SendNameTypeTry(sender, typ string) (emer.Prjn, error) {
+	return emer.SendNameTypeTry(ly, sender, typ)
+}
+func (ly *Layer) RecvNameTry(receiver string) (emer.Prjn, error) {
+	return emer.RecvNameTry(ly, receiver)
+}
+func (ly *Layer) RecvNameTypeTry(receiver, typ string) (emer.Prjn, error) {
+	return emer.RecvNameTypeTry(ly, receiver, typ)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
@@ -600,7 +613,7 @@ func (ly *Layer) SetWts(lw *weights.Layer) error {
 	} else {
 		for pi := range lw.Prjns {
 			pw := &lw.Prjns[pi]
-			pj := rpjs.SendName(pw.From)
+			pj, _ := ly.SendNameTry(pw.From)
 			if pj != nil {
 				er := pj.SetWts(pw)
 				if er != nil {
@@ -1219,7 +1232,7 @@ func (ly *Layer) GFmSpikeRaw(ni int, nrn *Neuron, ctime *Time) {
 		if p.IsOff() {
 			continue
 		}
-		pj := p.(AxonPrjn).AsAxon()
+		pj := p.AsAxon()
 		gv := pj.GVals[ni]
 		if pj.Typ == emer.Inhib {
 			nrn.GiRaw += gv.GRaw

--- a/axon/layerbase.go
+++ b/axon/layerbase.go
@@ -29,8 +29,8 @@ type LayerBase struct {
 	NeurStIdx int            `view:"-" inactive:"-" desc:"starting index of neurons for this layer within the global Network list"`
 	RepIxs    []int          `view:"-" desc:"indexes of representative units in the layer, for computationally expensive stats or displays -- also set RepShp"`
 	RepShp    etensor.Shape  `view:"-" desc:"shape of representative units in the layer -- if RepIxs is empty or .Shp is nil, use overall layer shape"`
-	RcvPrjns  emer.Prjns     `desc:"list of receiving projections into this layer from other layers"`
-	SndPrjns  emer.Prjns     `desc:"list of sending projections from this layer to other layers"`
+	RcvPrjns  AxonPrjns      `desc:"list of receiving projections into this layer from other layers"`
+	SndPrjns  AxonPrjns      `desc:"list of sending projections from this layer to other layers"`
 }
 
 // emer.Layer interface methods
@@ -76,10 +76,10 @@ func (ls *LayerBase) Pos() mat32.Vec3            { return ls.Ps }
 func (ls *LayerBase) SetPos(pos mat32.Vec3)      { ls.Ps = pos }
 func (ls *LayerBase) Index() int                 { return ls.Idx }
 func (ls *LayerBase) SetIndex(idx int)           { ls.Idx = idx }
-func (ls *LayerBase) RecvPrjns() *emer.Prjns     { return &ls.RcvPrjns }
+func (ls *LayerBase) RecvPrjns() *AxonPrjns      { return &ls.RcvPrjns }
 func (ls *LayerBase) NRecvPrjns() int            { return len(ls.RcvPrjns) }
 func (ls *LayerBase) RecvPrjn(idx int) emer.Prjn { return ls.RcvPrjns[idx] }
-func (ls *LayerBase) SendPrjns() *emer.Prjns     { return &ls.SndPrjns }
+func (ls *LayerBase) SendPrjns() *AxonPrjns      { return &ls.SndPrjns }
 func (ls *LayerBase) NSendPrjns() int            { return len(ls.SndPrjns) }
 func (ls *LayerBase) SendPrjn(idx int) emer.Prjn { return ls.SndPrjns[idx] }
 func (ls *LayerBase) RepIdxs() []int             { return ls.RepIxs }

--- a/axon/network.go
+++ b/axon/network.go
@@ -231,26 +231,26 @@ func (nt *Network) InitTopoSWts() {
 		if ly.IsOff() {
 			continue
 		}
-		rpjn := ly.RecvPrjns()
-		for _, p := range *rpjn {
-			if p.IsOff() {
+		for i := 0; i < ly.NRecvPrjns(); i++ {
+			recvPrjn := ly.RecvPrjn(i)
+			if recvPrjn.IsOff() {
 				continue
 			}
-			pat := p.Pattern()
+			pat := recvPrjn.Pattern()
 			switch pt := pat.(type) {
 			case *prjn.PoolTile:
 				if !pt.HasTopoWts() {
 					continue
 				}
-				pj := p.(AxonPrjn).AsAxon()
-				slay := p.SendLay()
+				pj := recvPrjn.(AxonPrjn).AsAxon()
+				slay := recvPrjn.SendLay()
 				pt.TopoWts(slay.Shape(), ly.Shape(), swts)
 				pj.SetSWtsRPool(swts)
 			case *prjn.Circle:
 				if !pt.TopoWts {
 					continue
 				}
-				pj := p.(AxonPrjn).AsAxon()
+				pj := recvPrjn.(AxonPrjn).AsAxon()
 				pj.SetSWtsFunc(pt.GaussWts)
 			}
 		}

--- a/examples/deep_music/deep_music.go
+++ b/examples/deep_music/deep_music.go
@@ -196,7 +196,8 @@ func (ss *Sim) ConfigNet(net *deep.Network) {
 		hid2, hid2ct = net.AddSuperCT2D("Hidden2", 20, nUnits, space, one2one) // one2one learn > full
 		net.ConnectCTSelf(hid2ct, full)
 		net.ConnectToPulv(hid2, hid2ct, inPulv, full, full) // shortcut top-down
-		inPulv.RecvPrjns().SendName(hid2ct.Name()).SetClass("CTToPulvHigher")
+		projection, _ := inPulv.SendNameTry(hid2ct.Name())
+		projection.SetClass("CTToPulvHigher")
 		// net.ConnectToPulv(hid2, hid2ct, hidp, full, full) // predict layer below -- not useful
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2
-	github.com/emer/emergent v1.3.31
+	github.com/emer/emergent v1.3.32
 	github.com/emer/empi v1.0.17
 	github.com/emer/etable v1.1.11
 	github.com/goki/gi v1.3.7

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
-github.com/emer/emergent v1.3.31 h1:vWLEoVR6iKQ/FvRv/rahYgHGfzaPi3SUOwjaICub3fA=
-github.com/emer/emergent v1.3.31/go.mod h1:EAywDpO2uGOiYmmjKio0YnCYa5Vu+BAMYWCIc1C8c4Y=
+github.com/emer/emergent v1.3.32 h1:P4AzSlxECpcU6cyz59lYDxT+JlW9qcdxpIyg+OP6/8g=
+github.com/emer/emergent v1.3.32/go.mod h1:EAywDpO2uGOiYmmjKio0YnCYa5Vu+BAMYWCIc1C8c4Y=
 github.com/emer/empi v1.0.17 h1:1arFWAzdDR9emrKbz2sTGMhfAa+Kk0y3UTeBW1j9ltw=
 github.com/emer/empi v1.0.17/go.mod h1:cwXlhwSb91QvfadOlVRrXvcpLGa1ld3GZme5ygb4kt8=
 github.com/emer/etable v1.1.11 h1:Cg0ih3sXKYBLiCwLYILE6yRNk3WdXwywMEVf9XY4Eto=


### PR DESCRIPTION
See corresponding emergent PR, which has to be merged first: https://github.com/emer/emergent/pull/103

Now `AxonLayer.RecvPrjns` returns `*[]AxonPrjn` instead of `*[]emer.Prjn`, saving us from having to do the type assertion in GFmSpikeRaw. Makes things ~8% faster for single-threaded runs of boa.