### PR TITLE
Update comment to match PPTg name used in code

### DIFF
--- a/pvlv/pptg.go
+++ b/pvlv/pptg.go
@@ -15,7 +15,7 @@ type PPTgNeuron struct {
 	GeSynPrev float32 `desc:"previous max excitatory synaptic inputs"`
 }
 
-// PPTgLayer represents a pedunculopontine nucleus layer
+// PPTgLayer represents a pedunculopontine tegmental nucleus layer.
 // it subtracts prior trial's excitatory conductance to
 // compute the temporal derivative over time, with a positive
 // rectification.


### PR DESCRIPTION
I guess PPTg is short for pedunculopontine tegmental nucleus.