### PR TITLE
Add PGO Test script

### DIFF
--- a/examples/bench/run_bench_pgo.sh
+++ b/examples/bench/run_bench_pgo.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -x
+
+go install golang.org/dl/go1.20rc2@latest
+go1.20rc2 download # if it doesn't find the binary, add $HOME/go/bin to $PATH
+
+# cd to the directory that contains this file
+cd "$(dirname "$0")"
+
+# if TMPDIR is not set, create a temp dir and use that
+if [[ -z "${TMPDIR:-}" ]]; then
+    TMPDIR=$(mktemp -d)
+fi
+
+# ================================================================
+# Run the benchmark with no PGO, generating a pprof file
+exe=${TMPDIR}/bench
+CMD=("${exe}" -test.bench=BenchmarkBenchNetFull -writestats)
+go1.20rc2 clean -cache # no idea if this is necessary or not
+go1.20rc2 test -c -o "${exe}" -pgo=off -gcflags=-m . &> no_pgo.txt
+
+${CMD[@]} -epochs 10 -pats 10 -units 2048 -test.cpuprofile=no_pgo.pprof $*
+
+# ================================================================
+# Run the benchmark with PGO
+exe=${TMPDIR}/benchpgo
+CMD=("${exe}" -test.bench=BenchmarkBenchNetFull -writestats)
+go1.20rc2 clean -cache # no idea if this is necessary or not
+go1.20rc2 test -c -o "${exe}" -pgo no_pgo.pprof -gcflags=-m . &> pgo.txt
+
+${CMD[@]} -epochs 10 -pats 10 -units 2048 -test.cpuprofile=pgo.pprof $*
+
+go tool pprof -png no_pgo.pprof
+mv profile001.png no_pgo.png
+go tool pprof -png pgo.pprof
+mv profile001.png pgo.png
+


### PR DESCRIPTION
Just adding it to keep it around. Current results on MBP:

No pgo: `Took  57.55 secs for 10 epochs, avg per epc:  5.755`
Yes pgo: `Took  53.58 secs for 10 epochs, avg per epc:  5.358`

I really don't understand how to get a good overview over the compiler's inlining decision, `-gcflags=-m` doesn't output anything useful. Maybe I should ask on the slack.