### PR TITLE
Panic if LayersByClass returns nothing

### DIFF
--- a/axon/networkbase.go
+++ b/axon/networkbase.go
@@ -139,7 +139,11 @@ func (nt *NetworkBase) LayersByClass(classes ...string) []string {
 	for _, lc := range classes {
 		nms = append(nms, nt.LayClassMap[lc]...)
 	}
-	return dedupe.DeDupe(nms)
+	layers := dedupe.DeDupe(nms)
+	if len(layers) == 0 {
+		panic("No Layers found!")
+	}
+	return layers
 }
 
 // StdVertLayout arranges layers in a standard vertical (z axis stack) layout, by setting

--- a/axon/networkbase.go
+++ b/axon/networkbase.go
@@ -141,7 +141,7 @@ func (nt *NetworkBase) LayersByClass(classes ...string) []string {
 	}
 	layers := dedupe.DeDupe(nms)
 	if len(layers) == 0 {
-		panic("No Layers found!")
+		panic(fmt.Sprintf("No Layers found for query: %#v. Basic layer types have been renamed since v1.7, use LayersByType for forward compatibility.", classes))
 	}
 	return layers
 }

--- a/axon/networkbase_test.go
+++ b/axon/networkbase_test.go
@@ -42,6 +42,10 @@ func TestDefaults(t *testing.T) {
 	assert.Nil(t, net.LayerByName("DoesNotExist"))
 	_, err := net.LayerByNameTry("DoesNotExist")
 	assert.Error(t, err)
+	val := net.LayersByType(InputLayer)
+	assert.Equal(t, 1, len(val))
+	val = net.LayersByClass("InputLayer")
+	assert.Equal(t, 1, len(val))
 
 	for layerIdx, layer := range net.Layers {
 		assert.Equal(t, layerIdx, layer.Index())


### PR DESCRIPTION
`LayersByClass` just caused me & Erdal to spend an hour pair-programming to figure out why ObjRec was broken after we updated Axon.
This is because `LayersByClass` just silently returns an empty list, if the passed string doesn't match anything.

The real fix would be to delete this function, and just keep `LayerByType`.
But for now, we just panic if it returns nothing.
