### PR TITLE
Get rid of malloc in Neuron hot loop

### DIFF
--- a/axon/Makefile
+++ b/axon/Makefile
@@ -19,7 +19,7 @@ gosl:
 	
 	
 # NOTE: MUST update version number here prior to running 'make release'
-VERS=v1.7.6
+VERS=v1.7.7
 PACKAGE=axon
 VERS_DATE=`date -u +%Y-%m-%d\ %H:%M`
 GIT_COMMIT=`git rev-parse --short HEAD`

--- a/axon/axon.go
+++ b/axon/axon.go
@@ -7,7 +7,6 @@ package axon
 import (
 	"github.com/emer/emergent/emer"
 	"github.com/emer/etable/etensor"
-	"github.com/goki/gosl/sltype"
 )
 
 // AxonNetwork defines the essential algorithmic API for Axon, at the network level.
@@ -171,7 +170,7 @@ type AxonLayer interface {
 
 	// GInteg integrates conductances G over time (Ge, NMDA, etc).
 	// reads pool Gi values.
-	GInteg(ctx *Context, ni uint32, nrn *Neuron, pl *Pool, vals *LayerVals, randctr *sltype.Uint2)
+	GInteg(ctx *Context, ni uint32, nrn *Neuron, pl *Pool, vals *LayerVals)
 
 	// SpikeFmG computes Vm from Ge, Gi, Gl conductances and then Spike from that
 	SpikeFmG(ctx *Context, ni uint32, nrn *Neuron)

--- a/axon/context.go
+++ b/axon/context.go
@@ -36,9 +36,9 @@ type Context struct {
 	Time        float32     `desc:"accumulated amount of time the network has been running, in simulation-time (not real world time), in seconds"`
 	Testing     slbool.Bool `desc:"if true, the model is being run in a testing mode, so no weight changes or other associated computations are needed.  this flag should only affect learning-related behavior"`
 	TimePerCyc  float32     `def:"0.001" desc:"amount of time to increment per cycle"`
-	RandsPerCyc uint32      `def:"2" desc:"maximum number of random numbers used per cycle, if noise is active -- we always just increase the random counter by this amount to maintain consistency"`
 
-	pad int32
+	pad  int32
+	pad1 int32
 
 	RandCtr  slrand.Counter `desc:"random counter -- incremented by maximum number of possible random numbers generated per cycle, regardless of how many are actually used -- this is shared across all layers so must encompass all possible param settings."`
 	NeuroMod NeuroModVals   `view:"inline" desc:"neuromodulatory state values -- these are computed separately on the CPU in CyclePost -- values are not cleared during running and remain until updated by a responsible layer type."`
@@ -47,7 +47,6 @@ type Context struct {
 // Defaults sets default values
 func (tm *Context) Defaults() {
 	tm.TimePerCyc = 0.001
-	tm.RandsPerCyc = 2
 	tm.ThetaCycles = 200
 }
 

--- a/axon/context.go
+++ b/axon/context.go
@@ -76,7 +76,7 @@ func (tm *Context) CycleInc() {
 	tm.Cycle++
 	tm.CycleTot++
 	tm.Time += tm.TimePerCyc
-	tm.RandCtr.Add(tm.RandsPerCyc)
+	tm.RandCtr.Add(uint32(RandFunIdxN))
 }
 
 //gosl: end time

--- a/axon/layer_compute.go
+++ b/axon/layer_compute.go
@@ -8,7 +8,6 @@ import (
 	"log"
 
 	"github.com/emer/etable/minmax"
-	"github.com/goki/gosl/sltype"
 	"github.com/goki/mat32"
 )
 
@@ -125,7 +124,7 @@ func (ly *Layer) PulvinarDriver(ni uint32) (drvGe, nonDrvPct float32) {
 
 // GInteg integrates conductances G over time (Ge, NMDA, etc).
 // calls SpecialGFmRawSyn, GiInteg
-func (ly *Layer) GInteg(ctx *Context, ni uint32, nrn *Neuron, pl *Pool, vals *LayerVals, randctr *sltype.Uint2) {
+func (ly *Layer) GInteg(ctx *Context, ni uint32, nrn *Neuron, pl *Pool, vals *LayerVals) {
 	drvGe := float32(0)
 	nonDrvPct := float32(0)
 	if ly.LayerType() == PulvinarLayer {
@@ -134,7 +133,7 @@ func (ly *Layer) GInteg(ctx *Context, ni uint32, nrn *Neuron, pl *Pool, vals *La
 
 	saveVal := ly.Params.SpecialPreGs(ctx, ni, nrn, drvGe, nonDrvPct)
 
-	ly.Params.GFmRawSyn(ctx, ni, nrn, randctr)
+	ly.Params.GFmRawSyn(ctx, ni, nrn)
 	ly.Params.GiInteg(ctx, ni, nrn, pl, vals)
 	ly.Params.GNeuroMod(ctx, ni, nrn, vals)
 
@@ -148,8 +147,7 @@ func (ly *Layer) SpikeFmG(ctx *Context, ni uint32, nrn *Neuron) {
 
 // CycleNeuron does one cycle (msec) of updating at the neuron level
 func (ly *Layer) CycleNeuron(ctx *Context, ni uint32, nrn *Neuron) {
-	randctr := ctx.RandCtr.Uint2() // use local var so updates are local
-	ly.AxonLay.GInteg(ctx, ni, nrn, &ly.Pools[nrn.SubPool], ly.Vals, &randctr)
+	ly.AxonLay.GInteg(ctx, ni, nrn, &ly.Pools[nrn.SubPool], ly.Vals)
 	ly.AxonLay.SpikeFmG(ctx, ni, nrn)
 }
 

--- a/axon/layerparams.go
+++ b/axon/layerparams.go
@@ -6,8 +6,6 @@ package axon
 
 import (
 	"encoding/json"
-
-	"github.com/goki/gosl/sltype"
 )
 
 //gosl: hlsl layerparams
@@ -301,7 +299,7 @@ func (ly *LayerParams) SpecialPostGs(ctx *Context, ni uint32, nrn *Neuron, saveV
 // GFmRawSyn computes overall Ge and GiSyn conductances for neuron
 // from GeRaw and GeSyn values, including NMDA, VGCC, AMPA, and GABA-A channels.
 // drvAct is for Pulvinar layers, activation of driving neuron
-func (ly *LayerParams) GFmRawSyn(ctx *Context, ni uint32, nrn *Neuron, randctr *sltype.Uint2) {
+func (ly *LayerParams) GFmRawSyn(ctx *Context, ni uint32, nrn *Neuron) {
 	extraRaw := float32(0)
 	extraSyn := float32(0)
 	if ly.LayType == PTMaintLayer {
@@ -335,10 +333,10 @@ func (ly *LayerParams) GFmRawSyn(ctx *Context, ni uint32, nrn *Neuron, randctr *
 	ly.Act.NMDAFmRaw(nrn, geRaw+extraRaw)
 	ly.Learn.LrnNMDAFmRaw(nrn, geRaw)
 	ly.Act.GvgccFmVm(nrn)
-	ly.Act.GeFmSyn(ni, nrn, geSyn, nrn.Gnmda+nrn.Gvgcc+extraSyn, randctr) // sets nrn.GeExt too
+	ly.Act.GeFmSyn(ctx, ni, nrn, geSyn, nrn.Gnmda+nrn.Gvgcc+extraSyn) // sets nrn.GeExt too
 	ly.Act.GkFmVm(nrn)
 	ly.Act.GSkCaFmCa(nrn)
-	nrn.GiSyn = ly.Act.GiFmSyn(ni, nrn, nrn.GiSyn, randctr)
+	nrn.GiSyn = ly.Act.GiFmSyn(ctx, ni, nrn, nrn.GiSyn)
 }
 
 // GiInteg adds Gi values from all sources including SubPool computed inhib

--- a/axon/rand.go
+++ b/axon/rand.go
@@ -1,0 +1,26 @@
+package axon
+
+import (
+	"github.com/goki/gosl/slrand"
+)
+
+type RandFunIdx uint32
+
+// We use this enum to store a unique index for each function that
+// requires random number generation. If you add a new function, you need to add
+// a new enum entry here.
+// RandFunIdxN is the total number of random functions. It autoincrements due to iota.
+const (
+	RandFunActPGe RandFunIdx = iota
+	RandFunActPGi
+	RandFunIdxN
+)
+
+// GetRandomNumber returns a random number that depends on the index, counter and function index.
+// We increment the counter after each cycle, so that we get new random numbers.
+// This whole scheme exists to ensure equal results under different multithreading settings.
+func GetRandomNumber(index uint32, counter slrand.Counter, funIdx RandFunIdx) float32 {
+	randCtr := counter.Uint2()
+	slrand.CounterAdd(&randCtr, uint32(funIdx))
+	return slrand.Float(&randCtr, index)
+}

--- a/axon/version.go
+++ b/axon/version.go
@@ -3,7 +3,7 @@
 package axon
 
 const (
-	Version     = "v1.7.6"
-	GitCommit   = "58cfa44"          // the commit JUST BEFORE the release
-	VersionDate = "2023-02-07 16:45" // UTC
+	Version     = "v1.7.7"
+	GitCommit   = "c8f33c3"          // the commit JUST BEFORE the release
+	VersionDate = "2023-02-08 23:48" // UTC
 )

--- a/examples/bench/run_bench.sh
+++ b/examples/bench/run_bench.sh
@@ -17,32 +17,53 @@ exe=${TMPDIR}/bench
 go test -c -o ${exe} .
 
 # typically run with -threads=N arg as follows:
-# $./run_bench.sh -thrNeuron=4 -thrSendSpike=4 -thrSynCa=4 -test.cpuprofile=cpu.prof
+# $./run_bench.sh -modelSize=<S,M,L,XL> -thrNeuron=4 -thrSendSpike=4 -thrSynCa=4 -test.cpuprofile=cpu.prof
 
 CMD=(${exe} -test.bench=BenchmarkBenchNetFull -writestats)
 
-echo " "
 echo "=============================================================="
-echo "SMALL Network (5 x 25 units)"
-${CMD[@]} -epochs 10 -pats 100 -units 25 $*
-echo " "
-echo "=============================================================="
-echo "MEDIUM Network (5 x 100 units)"
-${CMD[@]} -epochs 3 -pats 100 -units 100 $*
-echo " "
-echo "=============================================================="
-echo "LARGE Network (5 x 625 units)"
-${CMD[@]} -epochs 5 -pats 20 -units 625 $*
-echo " "
-echo "=============================================================="
-echo "HUGE Network (5 x 1024 units)"
-${CMD[@]} -epochs 5 -pats 10 -units 1024 $*
-# echo " "
-# echo "=============================================================="
-# echo "GINORMOUS Network (5 x 2048 units)"
-# ${CMD[@]} -epochs 2 -pats 10 -units 2048 $*
-# echo " "
-# echo "=============================================================="
-# echo "GAZILIOUS Network (5 x 4096 units)"
-# ${CMD[@]} -epochs=1 -pats=10 -units=4096 $*
 
+model_param=$1
+
+# Check if the first argument starts with "-modelSize="
+if [[ $model_param =~ ^-modelSize= ]]; then
+  # Extract the value of modelSize
+  model_size=${model_param#-modelSize=}
+  run_all=0
+
+  # Check if the value of modelSize is one of S M L XL XXL
+  if [[ $model_size == "S" || $model_size == "M" || $model_size == "L" || $model_size == "XL" ]]; then
+    echo "modelSize: $model_size"
+  else
+    echo "Error: Invalid value for modelSize."
+    echo "Valid values: S M L XL"
+    exit 1
+  fi
+
+  # Remove the first argument from the list of arguments
+  shift
+else
+  model_size=""
+  run_all=1
+fi
+
+if [[ $model_size == "S" || $run_all == 1 ]]; then
+  echo "SMALL Network (5 x 25 units)"
+  ${CMD[@]} -epochs 10 -pats 100 -units 25 $@
+  echo " "
+fi
+if [[ $model_size == "M" || $run_all == 1 ]]; then
+  echo "MEDIUM Network (5 x 100 units)"
+  ${CMD[@]} -epochs 3 -pats 100 -units 100 $@
+  echo " "
+fi
+if [[ $model_size == "L" || $run_all == 1 ]]; then
+  echo "LARGE Network (5 x 625 units)"
+  ${CMD[@]} -epochs 5 -pats 20 -units 625 $@
+  echo " "
+fi
+if [[ $model_size == "XL" || $run_all == 1 ]]; then
+  echo "HUGE Network (5 x 1024 units)"
+  ${CMD[@]} -epochs 5 -pats 10 -units 1024 $@
+  echo " "
+fi;


### PR DESCRIPTION
Problem: After the large refactor, we're now doing a lot of memory allocations in the hot loop of NeuronFun, creating a new randctr every time we call CycleNeuron. This costs time, and triggers a lot of calls to GC.

I don't know if you want to merge this PR, I'm not really sure why this new randcntr was introduced (seems to be related to GPU stuff). There may be a better way to solve this problem.

My solution: I moved the randctr allocation out of the hotloop. We now only allocate once per thread.

PS: As an aside, I wonder how you're dealing with this alloc & free on GPU.

<img width="1212" alt="image" src="https://user-images.githubusercontent.com/14908678/217636420-255f828c-36c0-461d-8a67-3628cdc85fa5.png">

