### PR TITLE
Multithread Dwt

### DIFF
--- a/axon/network.go
+++ b/axon/network.go
@@ -366,8 +366,8 @@ func (nt *Network) PlusPhaseImpl(ctx *Context) {
 
 // DWtImpl computes the weight change (learning) based on current running-average activation values
 func (nt *Network) DWtImpl(ctx *Context) {
-	nt.LayerMapSeq(func(ly AxonLayer) { ly.DWtLayer(ctx) }, "DWtLayer") // def no thr
-	nt.PrjnMapSeq(func(pj AxonPrjn) { pj.DWt(ctx) }, "DWt")             // def thread
+	nt.LayerMapSeq(func(ly AxonLayer) { ly.DWtLayer(ctx) }, "DWtLayer")              // def no thr
+	nt.PrjnMapParallel(func(pj AxonPrjn) { pj.DWt(ctx) }, "DWt", nt.Threads.Neurons) // def thread
 }
 
 // WtFmDWtImpl updates the weights from delta-weight changes.

--- a/axon/network.go
+++ b/axon/network.go
@@ -366,8 +366,8 @@ func (nt *Network) PlusPhaseImpl(ctx *Context) {
 
 // DWtImpl computes the weight change (learning) based on current running-average activation values
 func (nt *Network) DWtImpl(ctx *Context) {
-	nt.LayerMapSeq(func(ly AxonLayer) { ly.DWtLayer(ctx) }, "DWtLayer")              // def no thr
-	nt.PrjnMapParallel(func(pj AxonPrjn) { pj.DWt(ctx) }, "DWt", nt.Threads.Neurons) // def thread
+	nt.LayerMapSeq(func(ly AxonLayer) { ly.DWtLayer(ctx) }, "DWtLayer")            // def no thr
+	nt.PrjnMapParallel(func(pj AxonPrjn) { pj.DWt(ctx) }, "DWt", nt.Threads.SynCa) // def thread
 }
 
 // WtFmDWtImpl updates the weights from delta-weight changes.

--- a/axon/prjn_compute.go
+++ b/axon/prjn_compute.go
@@ -163,8 +163,7 @@ func (pj *Prjn) DWt(ctx *Context) {
 			sy := &syns[ci]
 			si := pj.Params.SynSendLayIdx(sy)
 			sn := &slay.Neurons[si]
-			subPool := &rlay.Pools[rn.SubPool]
-			pj.Params.DWtSyn(ctx, sy, sn, rn, layPool, subPool, isTarget)
+			pj.Params.DWtSyn(ctx, sy, sn, rn, layPool, isTarget)
 		}
 	}
 }

--- a/axon/prjnparams.go
+++ b/axon/prjnparams.go
@@ -243,23 +243,23 @@ func (pj *PrjnParams) CycleSynCaSyn(ctx *Context, sy *Synapse, sn, rn *Neuron) {
 // DWtSyn is the overall entry point for weight change (learning) at given synapse.
 // It selects appropriate function based on projection type.
 // rpl is the receiving layer SubPool
-func (pj *PrjnParams) DWtSyn(ctx *Context, sy *Synapse, sn, rn *Neuron, layPool, subPool *Pool, isTarget bool) {
+func (pj *PrjnParams) DWtSyn(ctx *Context, sy *Synapse, sn, rn *Neuron, layPool *Pool, isTarget bool) {
 	switch pj.PrjnType {
 	case RWPrjn:
-		pj.DWtSynRWPred(ctx, sy, sn, rn, layPool, subPool)
+		pj.DWtSynRWPred(ctx, sy, sn, rn)
 	case TDPredPrjn:
-		pj.DWtSynTDPred(ctx, sy, sn, rn, layPool, subPool)
+		pj.DWtSynTDPred(ctx, sy, sn, rn)
 	case MatrixPrjn:
-		pj.DWtSynMatrix(ctx, sy, sn, rn, layPool, subPool)
+		pj.DWtSynMatrix(ctx, sy, sn, rn, layPool)
 	default:
-		pj.DWtSynCortex(ctx, sy, sn, rn, layPool, subPool, isTarget)
+		pj.DWtSynCortex(ctx, sy, sn, rn, isTarget)
 	}
 }
 
 // DWtSynCortex computes the weight change (learning) at given synapse for cortex.
 // Uses synaptically-integrated spiking, computed at the Theta cycle interval.
 // This is the trace version for hidden units, and uses syn CaP - CaD for targets.
-func (pj *PrjnParams) DWtSynCortex(ctx *Context, sy *Synapse, sn, rn *Neuron, layPool, subPool *Pool, isTarget bool) {
+func (pj *PrjnParams) DWtSynCortex(ctx *Context, sy *Synapse, sn, rn *Neuron, isTarget bool) {
 	caM := sy.CaM
 	caP := sy.CaP
 	caD := sy.CaD
@@ -298,7 +298,7 @@ func (pj *PrjnParams) DWtSynCortex(ctx *Context, sy *Synapse, sn, rn *Neuron, la
 
 // DWtSynRWPred computes the weight change (learning) at given synapse,
 // for the RWPredPrjn type
-func (pj *PrjnParams) DWtSynRWPred(ctx *Context, sy *Synapse, sn, rn *Neuron, layPool, subPool *Pool) {
+func (pj *PrjnParams) DWtSynRWPred(ctx *Context, sy *Synapse, sn, rn *Neuron) {
 	// todo: move all of this into rn.RLRate
 	lda := ctx.NeuroMod.DA
 	da := lda
@@ -333,7 +333,7 @@ func (pj *PrjnParams) DWtSynRWPred(ctx *Context, sy *Synapse, sn, rn *Neuron, la
 
 // DWtSynTDPred computes the weight change (learning) at given synapse,
 // for the TDRewPredPrjn type
-func (pj *PrjnParams) DWtSynTDPred(ctx *Context, sy *Synapse, sn, rn *Neuron, layPool, subPool *Pool) {
+func (pj *PrjnParams) DWtSynTDPred(ctx *Context, sy *Synapse, sn, rn *Neuron) {
 	// todo: move all of this into rn.RLRate
 	lda := ctx.NeuroMod.DA
 	da := lda
@@ -356,7 +356,7 @@ func (pj *PrjnParams) DWtSynTDPred(ctx *Context, sy *Synapse, sn, rn *Neuron, la
 
 // DWtSynMatrix computes the weight change (learning) at given synapse,
 // for the MatrixPrjn type.
-func (pj *PrjnParams) DWtSynMatrix(ctx *Context, sy *Synapse, sn, rn *Neuron, layPool, subPool *Pool) {
+func (pj *PrjnParams) DWtSynMatrix(ctx *Context, sy *Synapse, sn, rn *Neuron, layPool *Pool) {
 	// note: rn.RLRate already has ACh * DA * (D1 vs. D2 sign reversal) factored in.
 
 	dtr := float32(0)

--- a/axon/threads.go
+++ b/axon/threads.go
@@ -157,7 +157,7 @@ func (nt *NetworkBase) LayerMapSeq(fun func(ly AxonLayer), funame string) {
 func (nt *NetworkBase) NeuronMapParallel(fun func(ly AxonLayer, ni uint32, nrn *Neuron), funame string, nThreads int) {
 	nt.FunTimerStart(funame)
 	if nThreads <= 1 {
-		nt.NeuronMapSequential(fun, funame)
+		nt.NeuronMapSeq(fun, funame)
 	} else {
 		parallelRun(func(st, ed int) {
 			for ni := st; ni < ed; ni++ {
@@ -170,8 +170,8 @@ func (nt *NetworkBase) NeuronMapParallel(fun func(ly AxonLayer, ni uint32, nrn *
 	nt.FunTimerStop(funame)
 }
 
-// NeuronMapSequential applies function of given name to all neurons sequentially.
-func (nt *NetworkBase) NeuronMapSequential(fun func(ly AxonLayer, ni uint32, nrn *Neuron), funame string) {
+// NeuronMapSeq applies function of given name to all neurons sequentially.
+func (nt *NetworkBase) NeuronMapSeq(fun func(ly AxonLayer, ni uint32, nrn *Neuron), funame string) {
 	nt.FunTimerStart(funame)
 	for _, layer := range nt.Layers {
 		lyr := layer.(AxonLayer)

--- a/axon/threads.go
+++ b/axon/threads.go
@@ -51,14 +51,14 @@ func (nt *NetThreads) SetDefaults(nNeurons, nPrjns, nLayers int) {
 	maxProcs := runtime.GOMAXPROCS(0) // query GOMAXPROCS
 
 	// heuristics
-	prjnMinThr := ints.MinInt(ints.MaxInt(nPrjns, 1), 4)
+	synCaHeur := ints.MaxInt(nPrjns, 1)
 	synHeur := math.Ceil(float64(nNeurons) / float64(1000))
 	neuronHeur := math.Ceil(float64(nNeurons) / float64(500))
 
 	if err := nt.Set(
 		ints.MinInt(maxProcs, int(neuronHeur)),
 		ints.MinInt(maxProcs, int(synHeur)),
-		ints.MinInt(maxProcs, int(prjnMinThr)),
+		ints.MinInt(maxProcs, int(synCaHeur)),
 	); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Turn on multithreading for DWt, it was running sequentially.

We could refactor both SynCa & DWt to multithread on a per-Neuron level, would probably make things even faster.