### PR TITLE
approach env: clean up InstinctAct

### DIFF
--- a/examples/boa/approach_env.go
+++ b/examples/boa/approach_env.go
@@ -337,19 +337,15 @@ func (ev *Approach) PosHasDriveUS() bool {
 func (ev *Approach) InstinctAct(justGated, hasGated bool) int {
 	ev.JustGated = justGated
 	ev.HasGated = hasGated
-	fwd := ev.ActMap["Forward"]
-	cons := ev.ActMap["Consume"]
-	ev.ShouldGate = false
+	ev.ShouldGate = ((hasGated && ev.US != noUS) || // To clear the goal after US
+		(!hasGated && ev.PosHasDriveUS())) // looking at correct, haven't yet gated
+
 	if ev.Dist == 0 {
-		if ev.LastAct == cons {
-			ev.ShouldGate = true
-		}
-		return cons
+		return ev.ActMap["Consume"]
 	}
 	if ev.HasGated {
-		return fwd
+		return ev.ActMap["Forward"]
 	}
-	ev.ShouldGate = ev.PosHasDriveUS() // looking at correct, haven't yet gated
 	lt := ev.ActMap["Left"]
 	rt := ev.ActMap["Right"]
 	if ev.LastAct == lt || ev.LastAct == rt {


### PR DESCRIPTION
* Don't rely on double consume to set ShouldGate.
  What really matters is that the agent currently has a goal engaged
  (`hasGated`) and just got a US (`ev.US != noUS`).
* Only set ShouldGate once. It's easier to understand if it doesn't
  change inside the function body IMHO.

Change-Id: I0334ec86acbbeafcf36a5b73824d80d396cf625b