### PR TITLE
PVLV: fix neg US code

### DIFF
--- a/axon/context.go
+++ b/axon/context.go
@@ -1014,17 +1014,6 @@ func PVLVHasPosUS(ctx *Context, di uint32) bool {
 	return false
 }
 
-// PVLVHasNegUS returns true if there is at least one non-zero negative US
-func PVLVHasNegUS(ctx *Context, di uint32) bool {
-	nd := ctx.PVLV.Drive.NActive
-	for i := uint32(0); i < nd; i++ {
-		if GlbDrvV(ctx, di, i, GvUSpos) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
 // PVLVNetPV returns VTA.Vals.PVpos - VTA.Vals.PVneg
 func PVLVNetPV(ctx *Context, di uint32) float32 {
 	return GlbVTA(ctx, di, GvVtaVals, GvVtaPVpos) - GlbVTA(ctx, di, GvVtaVals, GvVtaPVneg)
@@ -1036,16 +1025,6 @@ func PVLVNetPV(ctx *Context, di uint32) float32 {
 // usValue * drive * Effort.DiscFun(effort)
 func PVLVPosPVFmDriveEffort(ctx *Context, usValue, drive, effort float32) float32 {
 	return usValue * drive * ctx.PVLV.Effort.DiscFun(effort)
-}
-
-// PVLVSetPosUS sets given positive US (associated with same-indexed Drive) to given value
-func PVLVSetPosUS(ctx *Context, di uint32, usn uint32, val float32) {
-	SetGlbDrvV(ctx, di, usn, GvUSpos, val)
-}
-
-// PVLVSetNegUS sets given negative US to given value
-func PVLVSetNegUS(ctx *Context, di uint32, usn uint32, val float32) {
-	SetGlbDrvV(ctx, di, usn, GvUSneg, val)
 }
 
 // PVLVSetDrive sets given Drive to given value
@@ -1185,10 +1164,10 @@ func (ctx *Context) PVLVInitUS(di uint32) {
 // in the course of goal engaged approach.
 func (ctx *Context) PVLVSetUS(di uint32, valence ValenceTypes, usIdx int, magnitude float32) {
 	if valence == Positive {
-		SetGlbV(ctx, di, GvHasRew, 1)                     // only for positive USs
-		PVLVSetPosUS(ctx, di, uint32(usIdx)+1, magnitude) // +1 for curiosity
+		SetGlbV(ctx, di, GvHasRew, 1)                            // only for positive USs
+		SetGlbDrvV(ctx, di, uint32(usIdx)+1, GvUSpos, magnitude) // +1 for curiosity
 	} else {
-		PVLVSetNegUS(ctx, di, uint32(usIdx), magnitude)
+		SetGlbUSneg(ctx, di, uint32(usIdx), magnitude)
 	}
 }
 

--- a/axon/context_test.go
+++ b/axon/context_test.go
@@ -1,0 +1,33 @@
+package axon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetGetUS(t *testing.T) {
+	TheNetwork = NewNetwork("TestSetGetUS")
+	ctx := NewContext()
+	// TODO: seems impossible to test with only one drive
+	// because of the +1 for curiosity in PVLVSetUS.
+	ctx.PVLV.Drive.NActive = 2
+	require.NoError(t, TheNetwork.Build(ctx))
+	const di = 0
+	ctx.PVLVInitUS(di)
+	const usIdx = 0
+	assert.Equal(t, float32(0), PVLVUSStimVal(ctx, di, usIdx, Positive))
+	assert.Equal(t, float32(0), PVLVUSStimVal(ctx, di, usIdx, Negative))
+	assert.False(t, PVLVHasPosUS(ctx, di))
+
+	ctx.PVLVSetUS(di, Positive, usIdx, 1)
+	// TODO: +1 for curiosity is hard-coded into PVLVSetUS. This assymetry between the
+	// getter and setter seems bug-prone.
+	const usIdxForGetterPositive = usIdx + 1
+	assert.Equal(t, float32(1), PVLVUSStimVal(ctx, 0, usIdxForGetterPositive, Positive))
+	assert.True(t, PVLVHasPosUS(ctx, di))
+
+	ctx.PVLVSetUS(di, Negative, usIdx, 1)
+	assert.Equal(t, float32(1), PVLVUSStimVal(ctx, di, usIdx, Negative))
+}

--- a/examples/pvlv/effort_plot.go
+++ b/examples/pvlv/effort_plot.go
@@ -142,7 +142,7 @@ func (ss *DrEffPlot) TimeRun() {
 	axon.UrgencyReset(ctx, 0)
 	ut := ss.USTime.Min + rand.Intn(ss.USTime.Range())
 	dt.SetNumRows(ss.TimeSteps)
-	axon.PVLVSetPosUS(ctx, 0, 0, 0)
+	axon.SetGlbDrvV(ctx, 0, 1, axon.GvUSpos, 0)
 	axon.DrivesToBaseline(ctx, 0)
 	// pv.Update()
 	lastUS := 0
@@ -165,7 +165,7 @@ func (ss *DrEffPlot) TimeRun() {
 		dt.SetCellFloat("US", ti, float64(usv))
 		dt.SetCellFloat("Drive", ti, float64(dr))
 
-		axon.PVLVSetPosUS(ctx, 0, 0, usv)
+		axon.SetGlbDrvV(ctx, 0, 1, axon.GvUSpos, usv)
 		axon.SetGlbV(ctx, 0, axon.GvHasRewPrev, bools.ToFloat32(usv > 0))
 		ctx.PVLV.EffortUrgencyUpdt(ctx, 0, &ss.Rand, 0)
 		axon.PVLVDriveUpdt(ctx, 0)


### PR DESCRIPTION
Previous code was treating neg US as a drive, but it's not stored with the drives.

Delete PVLVHasNegUS: It was wrong and unused.

Change-Id: Iea0cd44c4cd3dd2b30968632cc8083c407a0ea25